### PR TITLE
Add PHP learning blocks builder

### DIFF
--- a/configure_block.php
+++ b/configure_block.php
@@ -1,0 +1,254 @@
+<?php
+$lessonId = $_GET['lesson'] ?? '';
+$index = (int)($_GET['index'] ?? 0);
+$path = 'data/lesson_'.$lessonId.'.json';
+if(!file_exists($path)) die('Lesson not found');
+$lesson = json_decode(file_get_contents($path), true);
+$block = $lesson['blocks'][$index];
+$type = $block['type'];
+$configPath = 'data/lesson_'.$lessonId.'_block'.$index.'.json';
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    file_put_contents($configPath, json_encode($_POST, JSON_PRETTY_PRINT));
+    header('Location: teacher_config.php?id='.$lessonId);
+    exit;
+}
+$existing = file_exists($configPath) ? json_decode(file_get_contents($configPath), true) : [];
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Configure Block</title>
+<style>
+body{font-family:Arial,sans-serif;}
+.button{padding:5px 10px;}
+.letters span{display:inline-block;padding:4px;border:1px solid #ccc;margin:2px;cursor:pointer;}
+.letters span.missing{background:#bef264;}
+</style>
+</head>
+<body>
+<h1>Configure <?php echo ucfirst($type); ?> Block</h1>
+<form method="post">
+<?php if($type==='flashcard'): ?>
+    <div id="pairs">
+    <?php if(!empty($existing['pairs'])): foreach($existing['pairs'] as $p): ?>
+        <div>English: <input type="text" name="pairs[][en]" value="<?php echo htmlspecialchars($p['en']); ?>"> Spanish: <input type="text" name="pairs[][es]" value="<?php echo htmlspecialchars($p['es']); ?>"></div>
+    <?php endforeach; endif; ?>
+    </div>
+    <button type="button" onclick="addPair()" class="button">Add Pair</button>
+<?php elseif($type==='translate'): ?>
+    <?php for($i=0;$i<4;$i++): $en=$existing['sentences'][$i]['en']??''; $es=$existing['sentences'][$i]['es']??''; ?>
+        <div>English: <input type="text" name="sentences[<?php echo $i; ?>][en]" value="<?php echo htmlspecialchars($en); ?>"><br>Spanish: <input type="text" name="sentences[<?php echo $i; ?>][es]" value="<?php echo htmlspecialchars($es); ?>"></div><br>
+    <?php endfor; ?>
+<?php elseif($type==='speakflashcard'): ?>
+    <div id="speakcards">
+    <?php if(!empty($existing['cards'])): foreach($existing['cards'] as $c): ?>
+        <div>
+            Question: <input type="text" name="cards[][question]" value="<?php echo htmlspecialchars($c['question']); ?>"><br>
+            Answer: <input type="text" name="cards[][answer]" value="<?php echo htmlspecialchars($c['answer']); ?>"><br>
+            Hint: <input type="text" name="cards[][hint]" value="<?php echo htmlspecialchars($c['hint']); ?>"><br>
+            Points: <input type="number" name="cards[][points]" value="<?php echo htmlspecialchars($c['points']); ?>">
+        </div><br>
+    <?php endforeach; endif; ?>
+    </div>
+    <button type="button" onclick="addSpeakCard()" class="button">Add Card</button>
+<?php elseif($type==='spell'): ?>
+    <div id="spellwords">
+    <?php if(!empty($existing['exercises'])): foreach($existing['exercises'] as $e): ?>
+        <div>Word: <input type="text" name="exercises[][word]" value="<?php echo htmlspecialchars($e['word']); ?>"> Points: <input type="number" name="exercises[][points]" value="<?php echo htmlspecialchars($e['points']); ?>"></div>
+    <?php endforeach; endif; ?>
+    </div>
+    <button type="button" onclick="addSpellWord()" class="button">Add Word</button>
+<?php elseif($type==='spellquiz'): ?>
+    <div id="spellquizWords">
+    <?php if(!empty($existing['exercises'])): foreach($existing['exercises'] as $i=>$e): ?>
+        <div class="exercise" data-index="<?php echo $i; ?>">
+            Word: <input type="text" name="exercises[<?php echo $i; ?>][word]" class="wordInput" value="<?php echo htmlspecialchars($e['word']); ?>">
+            <div class="letters"></div>
+            <div class="answerHidden"></div>
+            <input type="hidden" name="exercises[<?php echo $i; ?>][hint]" class="hintInput" value="<?php echo htmlspecialchars($e['hint'] ?? ''); ?>">
+            <div>Option1: <input type="text" name="exercises[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($e['options'][0] ?? ''); ?>">
+            Option2: <input type="text" name="exercises[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($e['options'][1] ?? ''); ?>">
+            Option3: <input type="text" name="exercises[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($e['options'][2] ?? ''); ?>">
+            Option4: <input type="text" name="exercises[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($e['options'][3] ?? ''); ?>"></div>
+        <?php if(!empty($e['answer'])): foreach($e['answer'] as $a): ?>
+            <input type="hidden" name="exercises[<?php echo $i; ?>][answer][]" value="<?php echo htmlspecialchars($a); ?>">
+        <?php endforeach; endif; ?>
+        </div><br>
+    <?php endforeach; endif; ?>
+    </div>
+    <button type="button" onclick="addSpellQuiz()" class="button">Add Word</button>
+<?php else: ?>
+    <label>Image URL:<br><input type="text" name="image" id="imageInput" value="<?php echo htmlspecialchars($existing['image'] ?? ''); ?>"></label><br><br>
+    <div id="imageContainer" style="position:relative;display:inline-block;">
+        <img id="bgImage" src="<?php echo htmlspecialchars($existing['image'] ?? ''); ?>" style="max-width:600px;<?php echo empty($existing['image'])?'display:none;':''; ?>">
+        <div id="hotspotArea" style="position:absolute;top:0;left:0;right:0;bottom:0;"></div>
+    </div>
+    <div id="hotspots">
+    <?php if(!empty($existing['hotspots'])): foreach($existing['hotspots'] as $i=>$hs): ?>
+        <div class="hotspot-form">
+            <input type="hidden" name="hotspots[<?php echo $i; ?>][x]" value="<?php echo $hs['x']; ?>">
+            <input type="hidden" name="hotspots[<?php echo $i; ?>][y]" value="<?php echo $hs['y']; ?>">
+            English: <input type="text" name="hotspots[<?php echo $i; ?>][en]" value="<?php echo htmlspecialchars($hs['en']); ?>">
+            Correct: <input type="text" name="hotspots[<?php echo $i; ?>][correct]" value="<?php echo htmlspecialchars($hs['correct']); ?>"><br>
+            Option1: <input type="text" name="hotspots[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($hs['options'][0] ?? ''); ?>">
+            Option2: <input type="text" name="hotspots[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($hs['options'][1] ?? ''); ?>">
+            Option3: <input type="text" name="hotspots[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($hs['options'][2] ?? ''); ?>">
+            Option4: <input type="text" name="hotspots[<?php echo $i; ?>][options][]" value="<?php echo htmlspecialchars($hs['options'][3] ?? ''); ?>">
+        </div><br>
+    <?php endforeach; endif; ?>
+    </div>
+    <p>Click on the image to add hotspots.</p>
+<?php endif; ?>
+    <input type="submit" value="Save" class="button">
+</form>
+<script>
+function addPair(){
+    const div=document.createElement('div');
+    div.innerHTML='English: <input type="text" name="pairs[][en]"> Spanish: <input type="text" name="pairs[][es]">';
+    document.getElementById('pairs').appendChild(div);
+}
+function addSpeakCard(){
+    const div=document.createElement('div');
+    div.innerHTML='Question: <input type="text" name="cards[][question]"><br>Answer: <input type="text" name="cards[][answer]"><br>Hint: <input type="text" name="cards[][hint]"><br>Points: <input type="number" name="cards[][points]" value="4">';
+    document.getElementById('speakcards').appendChild(div);
+    document.getElementById('speakcards').appendChild(document.createElement('br'));
+}
+function addSpellWord(){
+    const div=document.createElement('div');
+    div.innerHTML='Word: <input type="text" name="exercises[][word]"> Points: <input type="number" name="exercises[][points]" value="5">';
+    document.getElementById('spellwords').appendChild(div);
+}
+function addSpellQuiz(existing){
+    const list=document.getElementById('spellquizWords');
+    const idx=list.querySelectorAll('.exercise').length;
+    const div=document.createElement('div');
+    div.className='exercise';
+    div.dataset.index=idx;
+    div.innerHTML=`Word: <input type="text" class="wordInput" name="exercises[${idx}][word]">
+    <div class="letters"></div>
+    <div class="answerHidden"></div>
+    <input type="hidden" class="hintInput" name="exercises[${idx}][hint]">
+    <div>Option1: <input type="text" name="exercises[${idx}][options][]">
+    Option2: <input type="text" name="exercises[${idx}][options][]">
+    Option3: <input type="text" name="exercises[${idx}][options][]">
+    Option4: <input type="text" name="exercises[${idx}][options][]"></div><br>`;
+    list.appendChild(div);
+    setupSpellQuiz(div,idx,existing);
+}
+function setupSpellQuiz(div,idx,data){
+    const wordInput=div.querySelector('.wordInput');
+    const lettersDiv=div.querySelector('.letters');
+    const answerDiv=div.querySelector('.answerHidden');
+    const hintInput=div.querySelector('.hintInput');
+    function render(){
+        lettersDiv.innerHTML='';
+        answerDiv.innerHTML='';
+        const word=wordInput.value;
+        [...word].forEach((ch,i)=>{
+            const span=document.createElement('span');
+            span.textContent=ch;
+            span.style.cursor='pointer';
+            span.style.padding='2px';
+            span.addEventListener('click',()=>{span.classList.toggle('missing');update();});
+            lettersDiv.appendChild(span);
+        });
+        update();
+    }
+    function update(){
+        const word=wordInput.value;
+        const chars=word.split('');
+        const answer=[];
+        lettersDiv.querySelectorAll('span').forEach((sp,i)=>{
+            if(sp.classList.contains('missing')){chars[i]='_';answer.push(sp.textContent);}
+        });
+        hintInput.value=chars.join('');
+        answerDiv.innerHTML='';
+        answer.forEach(l=>{
+            const h=document.createElement('input');
+            h.type='hidden';
+            h.name=`exercises[${idx}][answer][]`;
+            h.value=l;
+            answerDiv.appendChild(h);
+        });
+    }
+    wordInput.addEventListener('input',render);
+    if(data){
+        wordInput.value=data.word||'';
+        render();
+        if(data.answer){
+            lettersDiv.querySelectorAll('span').forEach((sp)=>{
+                const count=data.answer.filter(a=>a===sp.textContent).length;
+                for(let i=0;i<count;i++){sp.classList.add('missing');}
+            });
+            update();
+        }
+        if(data.options){
+            div.querySelectorAll('input[name$="[options][]"]').forEach((inp,j)=>{inp.value=data.options[j]||'';});
+        }
+    } else {
+        render();
+    }
+}
+document.querySelectorAll('#spellquizWords .exercise').forEach((ex,idx)=>{
+    const data={
+        word:ex.querySelector('.wordInput').value,
+        answer:Array.from(ex.querySelectorAll('input[name$="[answer][]"]')).map(i=>i.value),
+        options:Array.from(ex.querySelectorAll('input[name$="[options][]"]')).map(i=>i.value),
+        hint:ex.querySelector('.hintInput').value
+    };
+    setupSpellQuiz(ex,idx,data);
+});
+// hotspot support
+const imageInput=document.getElementById('imageInput');
+if(imageInput){
+    const bg=document.getElementById('bgImage');
+    const area=document.getElementById('hotspotArea');
+    const list=document.getElementById('hotspots');
+    let hIndex=list.querySelectorAll('.hotspot-form').length;
+    // place existing markers
+    list.querySelectorAll('input[name$="[x]"]').forEach((inp,idx)=>{
+        const x=inp.value;
+        const y=list.querySelectorAll('input[name$="[y]"]')[idx].value;
+        const m=document.createElement('div');
+        m.style.position='absolute';
+        m.style.width='20px';
+        m.style.height='20px';
+        m.style.borderRadius='50%';
+        m.style.background='red';
+        m.style.left=x+'%';
+        m.style.top=y+'%';
+        area.appendChild(m);
+    });
+    imageInput.addEventListener('change',()=>{bg.src=imageInput.value; bg.style.display='block';});
+    area.addEventListener('click',e=>{
+        const rect=area.getBoundingClientRect();
+        const x=((e.clientX-rect.left)/rect.width*100).toFixed(2);
+        const y=((e.clientY-rect.top)/rect.height*100).toFixed(2);
+        const marker=document.createElement('div');
+        marker.style.position='absolute';
+        marker.style.width='20px';
+        marker.style.height='20px';
+        marker.style.borderRadius='50%';
+        marker.style.background='red';
+        marker.style.left=x+'%';
+        marker.style.top=y+'%';
+        area.appendChild(marker);
+        const div=document.createElement('div');
+        div.className='hotspot-form';
+        div.innerHTML='\
+            <input type="hidden" name="hotspots['+hIndex+'][x]" value="'+x+'">\
+            <input type="hidden" name="hotspots['+hIndex+'][y]" value="'+y+'">\
+            English: <input type="text" name="hotspots['+hIndex+'][en]">\
+            Correct: <input type="text" name="hotspots['+hIndex+'][correct]"><br>\
+            Option1: <input type="text" name="hotspots['+hIndex+'][options][]">\
+            Option2: <input type="text" name="hotspots['+hIndex+'][options][]">\
+            Option3: <input type="text" name="hotspots['+hIndex+'][options][]">\
+            Option4: <input type="text" name="hotspots['+hIndex+'][options][]">';
+        list.appendChild(div);
+        hIndex++;
+    });
+}
+</script>
+</body>
+</html>

--- a/index.php
+++ b/index.php
@@ -1,0 +1,19 @@
+<?php
+// Simple entry page
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Learning Blocks</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        a.button { display: inline-block; padding: 10px 15px; margin: 10px; background: #4CAF50; color: white; text-decoration: none; }
+    </style>
+</head>
+<body>
+    <h1>Learning Blocks</h1>
+    <a class="button" href="teacher.php">Teacher</a>
+    <a class="button" href="student.php">Student</a>
+</body>
+</html>

--- a/progress.php
+++ b/progress.php
@@ -1,0 +1,20 @@
+<?php
+$student = preg_replace('/[^A-Za-z0-9_]/','', $_GET['student'] ?? '');
+$files = glob('data/progress_'.$student.'_*.json');
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Progress</title>
+<style>body{font-family:Arial,sans-serif;}</style>
+</head>
+<body>
+<h1>Progress for <?php echo htmlspecialchars($student); ?></h1>
+<ul>
+<?php foreach($files as $f): $d=json_decode(file_get_contents($f),true); ?>
+<li>Lesson <?php echo $d['lesson']; ?>: <?php echo $d['score']; ?> / <?php echo $d['total']; ?></li>
+<?php endforeach; ?>
+</ul>
+</body>
+</html>

--- a/run_lesson.php
+++ b/run_lesson.php
@@ -1,0 +1,422 @@
+<?php
+$lessonId = $_GET['lesson'] ?? '';
+$student = preg_replace('/[^A-Za-z0-9_]/','', $_GET['student'] ?? '');
+$lessonPath = 'data/lesson_'.$lessonId.'.json';
+if(!file_exists($lessonPath)) die('Lesson not found');
+$lesson = json_decode(file_get_contents($lessonPath), true);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Lesson <?php echo htmlspecialchars($lesson['name']); ?></title>
+<style>
+body{font-family:Arial,sans-serif;}
+.hidden{display:none;}
+.correct{color:green;}
+.incorrect{color:red;}
+.button{padding:5px 10px;}
+.flashcard{border:1px solid #ccc;padding:20px;margin:20px;}
+.hotspot{position:absolute;width:30px;height:30px;border-radius:50%;background:#bef264;color:#000;display:flex;justify-content:center;align-items:center;cursor:pointer;font-weight:bold;transition:all .3s ease;z-index:10;}
+.hotspot:hover{transform:scale(1.2);background:#a8e04d;}
+.hotspot.expanded{width:auto;height:auto;border-radius:0.375rem;padding:0.5rem 1rem;}
+.hotspot.correct{background:#86efac;}
+.hotspot.incorrect{background:#fca5a5;}
+.quiz-container{position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:white;border:2px solid #bef264;border-radius:0.375rem;padding:1rem;z-index:100;display:none;}
+.quiz-container button{background:#bef264;color:#000;border:none;padding:0.5rem 1rem;font-size:1rem;font-weight:bold;cursor:pointer;border-radius:0.375rem;margin-top:1rem;text-align:left;margin-right:1rem;}
+.quiz-container button:hover{background:#a8e04d;}
+.title{background:#bef264;color:#000;font-size:1.25rem;font-weight:bold;padding:0.5rem 1rem;border-radius:0.375rem;margin-bottom:1rem;}
+.card{width:300px;height:200px;position:relative;margin:20px;border-radius:10px;box-shadow:0 4px 8px rgba(0,0,0,0.1);}
+.card-front,.card-back{position:absolute;width:100%;height:100%;text-align:center;display:flex;flex-direction:column;align-items:center;justify-content:center;font-size:1.5rem;border-radius:10px;transition:opacity 0.8s;}
+.card-front{background:#f8fafc;opacity:1;visibility:visible;}
+.card-back{background:#bef264;opacity:0;visibility:hidden;}
+.card.flipped .card-front{opacity:0;visibility:hidden;}
+.card.flipped .card-back{opacity:1;visibility:visible;}
+.controls{margin:20px;display:flex;gap:10px;}
+#listening{color:#4ade80;font-weight:bold;margin-top:10px;display:none;}
+.learning-block{width:80%;margin:20px;padding:20px;border:1px solid #6ea8ff;border-radius:10px;background:#fff;box-shadow:0 0 10px rgba(0,0,0,0.2);}
+.learning-block .row-container{display:flex;flex-direction:row;}
+.learning-block .box{width:40px;height:30px;margin:15px;padding:10px;border:1px solid #6ea8ff;border-radius:10px;background:#fff;box-shadow:0 0 10px rgba(0,0,0,0.2);font-size:19px;text-align:center;cursor:pointer;}
+.learning-block .selected-wrong{background-color:lightcoral!important;}
+.learning-block .selected-correct{background-color:lightgreen!important;}
+.spell-container{display:flex;flex-direction:column;align-items:center;padding:2rem;background:#fff;border-radius:0.375rem;box-shadow:0 4px 6px rgba(0,0,0,0.1);}
+.spell-container .title{background:#bef264;color:#000;font-size:1.25rem;font-weight:bold;padding:0.5rem 1rem;border-radius:0.375rem;margin-bottom:1rem;}
+.spell-container .question{margin:20px;font-size:1.5rem;line-height:1.6;text-align:center;}
+.spell-container .word{font-size:2.8rem;font-weight:bold;margin:1rem 0;}
+.spell-container .options{display:flex;justify-content:center;gap:10px;margin-top:1rem;}
+.spell-container .option{background:#bef264;color:#000;border:none;padding:0.5rem 1rem;font-size:1.5rem;font-weight:bold;cursor:pointer;border-radius:0.375rem;}
+.spell-container .option:hover{background:#a8e04d;}
+.spell-score{font-size:1.25rem;font-weight:bold;margin-top:1rem;color:#000;}
+</style>
+</head>
+<body>
+<h1><?php echo htmlspecialchars($lesson['name']); ?></h1>
+<div id="blocks"></div>
+<div id="result" class="hidden"></div>
+<script>
+const lesson = <?php echo json_encode($lesson); ?>;
+let score=0,total=0;let current=0;let timer;
+function showBlock(i){
+    if(i>=lesson.blocks.length){
+        document.getElementById('blocks').innerHTML='';
+        const res=document.getElementById('result');
+        res.textContent='Finished! Score: '+score+'/'+total;
+        res.classList.remove('hidden');
+        fetch('save_progress.php',{
+            method:'POST',
+            headers:{'Content-Type':'application/json'},
+            body:JSON.stringify({student:'<?php echo $student; ?>',lesson:lesson.id,score:score,total:total})
+        });
+        return;
+    }
+    const block=lesson.blocks[i];
+    fetch('data/lesson_'+lesson.id+'_block'+i+'.json')
+        .then(r=>r.json())
+        .then(cfg=>{
+            if(block.type==='flashcard') flashcard(cfg,i);
+            else if(block.type==='speakflashcard') speakFlash(cfg,i);
+            else if(block.type==='translate') translate(cfg,i);
+            else if(block.type==='spell') spell(cfg,i);
+            else if(block.type==='spellquiz') spellQuiz(cfg,i);
+            else hotspot(cfg,i);
+        });
+}
+function flashcard(cfg,i){
+    let container=document.getElementById('blocks');
+    container.innerHTML='';
+    const div=document.createElement('div');
+    div.className='flashcard';
+    const startBtn=document.createElement('button');
+    startBtn.textContent='Start';
+    startBtn.className='button';
+    div.appendChild(startBtn);
+    const timerSpan=document.createElement('span');
+    timerSpan.style.marginLeft='10px';
+    div.appendChild(timerSpan);
+    const cardDiv=document.createElement('div');
+    div.appendChild(cardDiv);
+    container.appendChild(div);
+    let index=0;
+    startBtn.onclick=()=>{
+        total+=cfg.pairs.length;
+        startBtn.disabled=true;
+        let time=120;
+        timerSpan.textContent=time+'s';
+        timer=setInterval(()=>{time--;timerSpan.textContent=time+'s'; if(time<=0){clearInterval(timer); showBlock(i+1);}},1000);
+        showCard();
+    };
+    function showCard(){
+        if(index>=cfg.pairs.length){ clearInterval(timer); showBlock(i+1); return; }
+        const pair=cfg.pairs[index];
+        cardDiv.innerHTML='';
+        const en=document.createElement('div'); en.textContent=pair.en; cardDiv.appendChild(en);
+        const knowBtn=document.createElement('button'); knowBtn.textContent='I know it'; knowBtn.className='button';
+        const dontBtn=document.createElement('button'); dontBtn.textContent="I don't know"; dontBtn.className='button';
+        cardDiv.appendChild(document.createElement('br'));
+        cardDiv.appendChild(knowBtn); cardDiv.appendChild(dontBtn);
+        const answerDiv=document.createElement('div'); cardDiv.appendChild(answerDiv);
+        knowBtn.onclick=()=>{
+            knowBtn.disabled=true; dontBtn.disabled=true;
+            const input=document.createElement('input');
+            answerDiv.appendChild(input);
+            const chars=['á','é','í','ó','ú','ñ','¿','¡'];
+            const charDiv=document.createElement('div');
+            chars.forEach(c=>{const b=document.createElement('button');b.type='button';b.textContent=c;b.onclick=()=>{input.value+=c;};charDiv.appendChild(b);});
+            answerDiv.appendChild(charDiv);
+            const check=document.createElement('button');check.textContent='Check';check.className='button';answerDiv.appendChild(check);
+            check.onclick=()=>{
+                if(input.value.trim().toLowerCase()===pair.es.trim().toLowerCase())score++; index++; showCard();
+            };
+        };
+        dontBtn.onclick=()=>{ answerDiv.textContent=pair.es; index++; setTimeout(showCard,1000); };
+    }
+}
+function speakFlash(cfg,i){
+    const container=document.getElementById('blocks');
+    container.innerHTML='';
+    const title=document.createElement('div');
+    title.className='title';
+    title.textContent='Speak Flashcards';
+    container.appendChild(title);
+    const scoreDiv=document.createElement('div');
+    scoreDiv.id='score';
+    scoreDiv.textContent='Score: '+score;
+    container.appendChild(scoreDiv);
+    const message=document.createElement('div');
+    message.id='message';
+    container.appendChild(message);
+    const listening=document.createElement('div');
+    listening.id='listening';
+    listening.textContent='Listening...';
+    listening.style.display='none';
+    container.appendChild(listening);
+    const cardContainer=document.createElement('div');
+    cardContainer.className='card';
+    cardContainer.innerHTML='<div class="card-inner"><div class="card-front"><div class="question"></div></div><div class="card-back"></div></div>';
+    container.appendChild(cardContainer);
+    const controls=document.createElement('div');
+    controls.className='controls';
+    controls.innerHTML='<button type="button">I Know This!</button><button type="button">Show Hint</button><button type="button">Next Question</button>';
+    container.appendChild(controls);
+    const knowBtn=controls.children[0];
+    const hintBtn=controls.children[1];
+    const nextBtn=controls.children[2];
+
+    let currentCardIndex=0;
+    let hintUsed=false;
+    const pointsTotal=cfg.cards.reduce((s,c)=>s+parseInt(c.points||0),0);
+    total+=pointsTotal;
+
+    const SpeechRecognition = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const recognition = new SpeechRecognition();
+    recognition.lang = 'es-ES';
+    recognition.continuous = false;
+    recognition.interimResults = false;
+
+    recognition.onresult = (event) => {
+        const spokenText = event.results[0][0].transcript.toLowerCase().trim();
+        const currentCard = cfg.cards[currentCardIndex];
+        listening.style.display='none';
+        if (spokenText === currentCard.answer.toLowerCase() && !hintUsed) {
+            score += parseInt(currentCard.points);
+            scoreDiv.textContent='Score: '+score;
+            showMessage('Correct! +' + currentCard.points + ' points', false);
+            cardContainer.classList.add('flipped');
+        } else if (spokenText === currentCard.answer.toLowerCase() && hintUsed) {
+            const pts=Math.floor(parseInt(currentCard.points)/2);
+            score += pts;
+            scoreDiv.textContent='Score: '+score;
+            showMessage('Correct with hint! +' + pts + ' points', false);
+            cardContainer.classList.add('flipped');
+        } else {
+            showMessage('Try again. You said: ' + spokenText, true);
+            return;
+        }
+        currentCardIndex++;
+    };
+    recognition.onend = () => {
+        listening.style.display='none';
+        if(currentCardIndex>=cfg.cards.length){
+            setTimeout(()=>showBlock(i+1),500);
+        }else{
+            showCard();
+        }
+    };
+
+    knowBtn.onclick=()=>{
+        listening.style.display='block';
+        recognition.start();
+    };
+    hintBtn.onclick=()=>{
+        const current = cfg.cards[currentCardIndex];
+        showMessage('Hint: '+current.hint,false);
+        hintUsed=true;
+        hintBtn.style.backgroundColor='#fde047';
+    };
+    nextBtn.onclick=()=>{
+        cardContainer.classList.remove('flipped');
+        currentCardIndex=(currentCardIndex+1)%cfg.cards.length;
+        hintUsed=false;
+        hintBtn.style.backgroundColor='#bef264';
+        showCard();
+    };
+
+    function showCard(){
+        const card = cfg.cards[currentCardIndex];
+        cardContainer.querySelector('.question').textContent=card.question;
+        cardContainer.querySelector('.card-back').textContent=card.answer;
+    }
+    function showMessage(text,isError){
+        message.textContent=text;
+        message.style.color=isError?'red':'green';
+        setTimeout(()=>{message.textContent='';},3000);
+    }
+
+    showCard();
+}
+function translate(cfg,i){
+    const container=document.getElementById('blocks');
+    container.innerHTML='';
+    const form=document.createElement('div');
+    cfg.sentences.forEach((s,idx)=>{
+        const wrap=document.createElement('div');
+        wrap.innerHTML='<div>'+s.en+'</div>';
+        const input=document.createElement('input');
+        wrap.appendChild(input);
+        const fb=document.createElement('div'); wrap.appendChild(fb);
+        form.appendChild(wrap);
+        total++;
+        input.addEventListener('keyup',()=>{
+            const words=input.value.trim().split(/\s+/);
+            const target=s.es.trim().split(/\s+/);
+            fb.innerHTML='';
+            words.forEach((w,j)=>{
+                const span=document.createElement('span');
+                span.textContent=w+' ';
+                if(w===target[j]) span.className='correct'; else span.className='incorrect';
+                fb.appendChild(span);
+            });
+            if(input.value.trim().toLowerCase()===s.es.trim().toLowerCase()){
+                input.dataset.correct='1';
+            }else{
+                input.dataset.correct='0';
+            }
+        });
+    });
+    const done=document.createElement('button');done.textContent='Next';done.className='button';form.appendChild(done);
+    container.appendChild(form);
+    done.onclick=()=>{
+        const inputs=form.querySelectorAll('input');
+        inputs.forEach(inp=>{ if(inp.dataset.correct==='1') score++; });
+        showBlock(i+1);
+    };
+}
+function spell(cfg,i){
+    const container=document.getElementById('blocks');
+    container.innerHTML='';
+    let idx=0; let currentGuess=''; let selected='';
+    cfg.exercises.forEach(ex=>{total+=parseInt(ex.points||5);});
+    const block=document.createElement('div');
+    block.className='learning-block';
+    container.appendChild(block);
+    const header=document.createElement('h2'); header.textContent='Vocabulary Exercise: Spelling'; block.appendChild(header);
+    const info=document.createElement('p'); info.textContent='Listen and put the letters in order to spell the words.'; block.appendChild(info);
+    const audioBtn=document.createElement('button'); audioBtn.textContent='🔊'; audioBtn.className='box'; block.appendChild(audioBtn);
+    const rowLetters=document.createElement('div'); rowLetters.className='row-container'; block.appendChild(rowLetters);
+    const rowGaps=document.createElement('div'); rowGaps.className='row-container'; block.appendChild(rowGaps);
+    audioBtn.onclick=speak;
+    load();
+    function load(){
+        if(idx>=cfg.exercises.length){ showBlock(i+1); return; }
+        rowLetters.innerHTML=''; rowGaps.innerHTML=''; currentGuess=''; selected='';
+        const word=cfg.exercises[idx].word;
+        const letters=word.split('').sort(()=>0.5-Math.random());
+        letters.forEach(l=>{const b=document.createElement('div');b.className='box';b.textContent=l;b.onclick=()=>{selected=l;};rowLetters.appendChild(b);});
+        for(let k=0;k<word.length;k++){const gap=document.createElement('div');gap.className='box gap';gap.onclick=function(){if(selected&&this.textContent===''){this.textContent=selected;currentGuess+=selected;selected='';check();}};rowGaps.appendChild(gap);}    }
+    function speak(){
+        const msg=new SpeechSynthesisUtterance(cfg.exercises[idx].word); msg.lang='es-MX'; window.speechSynthesis.speak(msg);
+    }
+    function check(){
+        const word=cfg.exercises[idx].word;
+        if(currentGuess.length===word.length){
+            if(currentGuess===word){
+                score+=parseInt(cfg.exercises[idx].points||5);
+                alert('Correct! Score: '+score);
+                idx++; load();
+            }else{
+                alert('Try again!');
+                rowGaps.querySelectorAll('.gap').forEach(g=>g.textContent='');
+                currentGuess='';
+            }
+        }
+    }
+}
+function spellQuiz(cfg,i){
+    const container=document.getElementById('blocks');
+    container.innerHTML='';
+    const wrap=document.createElement('div');
+    wrap.className='spell-container';
+    wrap.innerHTML='<div class="title">Spelling Pop Quiz</div><div class="question">Look at the incomplete Spanish word. Click on the missing letter(s) in correct order to complete it.</div><div class="word" id="word"></div><div class="options" id="options"></div><div class="spell-score" id="spellScore">Score: '+score+'</div>';
+    container.appendChild(wrap);
+    const wordEl=wrap.querySelector('#word');
+    const opts=wrap.querySelector('#options');
+    const scoreDiv=wrap.querySelector('#spellScore');
+    let idx=0;
+    let user=[];
+    total+=cfg.exercises.length;
+    load();
+    function load(){
+        if(idx>=cfg.exercises.length){ showBlock(i+1); return; }
+        const ex=cfg.exercises[idx];
+        wordEl.textContent=ex.hint;
+        opts.innerHTML='';
+        user=[];
+        ex.options.forEach(o=>{
+            const b=document.createElement('button');
+            b.className='option';
+            b.textContent=o;
+            b.addEventListener('click',()=>choose(o));
+            opts.appendChild(b);
+        });
+    }
+    function choose(letter){
+        const ex=cfg.exercises[idx];
+        const cur=wordEl.textContent;
+        user.push(letter);
+        wordEl.textContent=cur.replace(/_/,letter);
+        if(user.length===ex.answer.length){
+            const ok=user.every((l,n)=>l===ex.answer[n]);
+            wordEl.classList.add(ok?'correct':'incorrect');
+            if(ok) score++;
+            scoreDiv.textContent='Score: '+score;
+            setTimeout(()=>{wordEl.classList.remove('correct','incorrect');idx++;load();},1500);
+        }
+    }
+}
+function hotspot(cfg,i){
+    const container=document.getElementById('blocks');
+    container.innerHTML='';
+    const bodyDiv=document.createElement('div');
+    bodyDiv.style.position='relative';
+    bodyDiv.style.width='600px';
+    bodyDiv.style.margin='20px auto';
+    bodyDiv.style.backgroundImage='url('+cfg.image+')';
+    bodyDiv.style.backgroundSize='contain';
+    bodyDiv.style.backgroundRepeat='no-repeat';
+    bodyDiv.style.backgroundPosition='center';
+    bodyDiv.style.height='780px';
+    container.appendChild(bodyDiv);
+    const scoreDiv=document.createElement('div'); scoreDiv.id='score'; scoreDiv.textContent='Score: '+score; container.appendChild(scoreDiv);
+    const message=document.createElement('div'); message.id='message'; container.appendChild(message);
+    const quiz=document.createElement('div'); quiz.className='quiz-container'; quiz.id='quizContainer'; quiz.innerHTML='<h2></h2><div id="quizOptions"></div>'; container.appendChild(quiz);
+    total+=cfg.hotspots.length;
+    let remaining=cfg.hotspots.length;
+    cfg.hotspots.forEach(hs=>{
+        const spot=document.createElement('div');
+        spot.className='hotspot';
+        spot.style.left=hs.x+'%';
+        spot.style.top=hs.y+'%';
+        spot.textContent='?';
+        bodyDiv.appendChild(spot);
+        let state='hidden';
+        spot.addEventListener('click',()=>{
+            if(state==='hidden'){
+                spot.textContent=hs.correct;
+                spot.classList.add('expanded');
+                state='revealed';
+            }else if(state==='revealed'){
+                spot.classList.remove('expanded');
+                spot.textContent='✓';
+                state='attempted';
+                spot.style.pointerEvents='none';
+                showQuiz(hs,spot);
+            }
+        });
+    });
+    function showQuiz(hs,spot){
+        const question=quiz.querySelector('h2');
+        const optionsDiv=document.getElementById('quizOptions');
+        optionsDiv.innerHTML='';
+        question.textContent="What's the word for \""+hs.en+"\"?";
+        hs.options.forEach(o=>{
+            const b=document.createElement('button'); b.textContent=o; b.addEventListener('click',()=>checkAnswer(hs,spot,o)); optionsDiv.appendChild(b);
+        });
+        quiz.style.display='block';
+    }
+    function checkAnswer(hs,spot,ans){
+        if(ans===hs.correct){
+            score+=20;
+            spot.classList.add('correct');
+            message.textContent='Correct!'; message.style.color='green';
+        }else{
+            spot.classList.add('incorrect');
+            message.textContent='Incorrect. Correct: '+hs.correct; message.style.color='red';
+        }
+        remaining--; scoreDiv.textContent='Score: '+score; quiz.style.display='none';
+        if(remaining===0){ setTimeout(()=>showBlock(i+1),500); }
+    }
+}
+showBlock(current);
+</script>
+</body>
+</html>

--- a/save_progress.php
+++ b/save_progress.php
@@ -1,0 +1,6 @@
+<?php
+$data = json_decode(file_get_contents('php://input'), true);
+if(!$data) exit;
+$file = 'data/progress_'.$data['student'].'_'.$data['lesson'].'.json';
+file_put_contents($file, json_encode($data, JSON_PRETTY_PRINT));
+?>

--- a/student.php
+++ b/student.php
@@ -1,0 +1,23 @@
+<?php
+$lessons = glob('data/lesson_*.json');
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Student Lessons</title>
+<style>body{font-family:Arial,sans-serif;} a.button{display:inline-block;padding:5px 10px;background:#4CAF50;color:#fff;text-decoration:none;margin:5px;}</style>
+</head>
+<body>
+<h1>Select Lesson</h1>
+<form method="get" action="run_lesson.php">
+<label>Your Name:<br><input type="text" name="student" required></label><br><br>
+<select name="lesson">
+<?php foreach($lessons as $f): $id=basename($f,'\.json'); $data=json_decode(file_get_contents($f),true); ?>
+    <option value="<?php echo substr($id,7); ?>"><?php echo htmlspecialchars($data['name']); ?></option>
+<?php endforeach; ?>
+</select>
+<input type="submit" value="Start" class="button">
+</form>
+</body>
+</html>

--- a/teacher.php
+++ b/teacher.php
@@ -1,0 +1,42 @@
+<?php
+// Teacher form to create a lesson with blocks
+?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Create Lesson</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .block { border:1px solid #ccc; padding:10px; margin:10px 0; }
+        .button { padding:5px 10px; }
+    </style>
+</head>
+<body>
+<h1>Create Lesson</h1>
+<form method="post" action="teacher_save.php" id="lessonForm">
+    <label>Lesson Name:<br><input type="text" name="name" required></label><br><br>
+    <label>Date:<br><input type="date" name="date" required></label><br><br>
+    <div id="blocks"></div>
+    <button type="button" onclick="addBlock('flashcard')" class="button">Add Flashcard Block</button>
+    <button type="button" onclick="addBlock('speakflashcard')" class="button">Add Speak Flashcards Block</button>
+    <button type="button" onclick="addBlock('translate')" class="button">Add Translate Block</button>
+    <button type="button" onclick="addBlock('hotspot')" class="button">Add Hotspot Block</button>
+    <button type="button" onclick="addBlock('spell')" class="button">Add Spelling Block</button><br><br>
+    <button type="button" onclick="addBlock('spellquiz')" class="button">Add Spelling Quiz Block</button><br><br>
+    <input type="submit" value="Save Lesson" class="button">
+</form>
+<script>
+let blockCount = 0;
+function addBlock(type){
+    const div = document.createElement('div');
+    div.className='block';
+    div.textContent = type.charAt(0).toUpperCase()+type.slice(1)+" Block";
+    div.innerHTML += '<input type="hidden" name="blocks['+blockCount+'][type]" value="'+type+'">';
+    div.innerHTML += '<input type="hidden" name="blocks['+blockCount+'][id]" value="'+Date.now()+blockCount+'">';
+    document.getElementById('blocks').appendChild(div);
+    blockCount++;
+}
+</script>
+</body>
+</html>

--- a/teacher_config.php
+++ b/teacher_config.php
@@ -1,0 +1,23 @@
+<?php
+$id = $_GET['id'] ?? '';
+$path = 'data/lesson_'.$id.'.json';
+if(!file_exists($path)) die('Lesson not found');
+$lesson = json_decode(file_get_contents($path), true);
+?>
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="UTF-8">
+<title>Configure Lesson</title>
+<style>body{font-family:Arial,sans-serif;} a.button{display:inline-block;padding:5px 10px;background:#4CAF50;color:#fff;text-decoration:none;margin:5px;}</style>
+</head>
+<body>
+<h1>Configure Lesson: <?php echo htmlspecialchars($lesson['name']); ?></h1>
+<ul>
+<?php foreach($lesson['blocks'] as $i=>$b): ?>
+<li><?php echo ucfirst($b['type']); ?> Block - <a class="button" href="configure_block.php?lesson=<?php echo $id; ?>&index=<?php echo $i; ?>">Configure</a></li>
+<?php endforeach; ?>
+</ul>
+<a href="index.php" class="button">Home</a>
+</body>
+</html>

--- a/teacher_save.php
+++ b/teacher_save.php
@@ -1,0 +1,14 @@
+<?php
+if($_SERVER['REQUEST_METHOD']==='POST'){
+    $lesson = [
+        'id' => time(),
+        'name' => $_POST['name'] ?? '',
+        'date' => $_POST['date'] ?? '',
+        'blocks' => $_POST['blocks'] ?? []
+    ];
+    if(!is_dir('data')) mkdir('data');
+    file_put_contents('data/lesson_'.$lesson['id'].'.json', json_encode($lesson, JSON_PRETTY_PRINT));
+    header('Location: teacher_config.php?id='.$lesson['id']);
+    exit;
+}
+?>


### PR DESCRIPTION
## Summary
- build entry page with Teacher and Student options
- add teacher workflow to create lessons and configure blocks
- implement flashcard and translate blocks with interactive JS
- save lesson data and student progress to JSON files in `/data`
- provide simple student interface and progress page
- add hotspot learning block with image-based hotspots
- add speak flashcards block with speech recognition
- add teacher-configurable spelling block for listening practice
- **add spelling quiz block where teachers select missing letters**

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841c865d788832198215eba14c3b81f